### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,4 +6,7 @@ build:
     python: "mambaforge-4.10"
 
 conda:
-  environment: docs/build-environment.yml
+  environment: "docs/build-environment.yml"
+
+sphinx:
+  configuration: "docs/conf.py"


### PR DESCRIPTION


This style has been deprecated since 2024 :) https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/