### PR TITLE
Fix unresponsive zoom behavior

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -10,7 +10,6 @@ import {
 import { LayerModel, LayerView } from './layer';
 import { BaseOverlayModel, BaseOverlayView } from './baseoverlay';
 import { BaseControlModel, BaseControlView } from './basecontrol';
-import { ViewObjectEventTypes } from 'ol/View';
 import TileLayer from 'ol/layer/Tile';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
 import { Map } from 'ol';
@@ -19,7 +18,6 @@ import 'ol/ol.css';
 import { MODULE_NAME, MODULE_VERSION } from './version';
 import '../css/widget.css';
 import { useGeographic } from 'ol/proj';
-import { ObjectEvent } from 'ol/Object';
 import { OSM } from 'ol/source';
 export * from './imageoverlay';
 export * from './geojson';
@@ -127,17 +125,20 @@ export class MapView extends DOMWidgetView {
       this.handleMapClick(event);
     });
 
-    this.map.getView().on('change:center', () => {
-      this.model.set('center', this.map.getView().getCenter());
+    this.map.on('moveend', () => {
+      const view = this.map.getView();
+      const zoom = view.getZoom();
+      const center = view.getCenter();
+
+      if (zoom !== undefined && zoom !== null) {
+        this.model.set('zoom', zoom);
+      }
+      if (center !== undefined && center !== null) {
+        this.model.set('center', center);
+      }
+
       this.model.save_changes();
     });
-
-    this.map
-      .getView()
-      .on('change:resolution' as ViewObjectEventTypes, (event: ObjectEvent) => {
-        this.model.set('zoom', this.map.getView().getZoom());
-        this.model.save_changes();
-      });
 
     this.layersChanged();
     this.overlayChanged();
@@ -171,15 +172,27 @@ export class MapView extends DOMWidgetView {
 
   zoomChanged() {
     const newZoom = this.model.get('zoom');
-    if (newZoom !== undefined && newZoom !== null) {
-      this.map.getView().setZoom(newZoom);
+    const view = this.map.getView();
+    const currentZoom = view.getZoom();
+
+    if (newZoom !== undefined && newZoom !== null && newZoom !== currentZoom) {
+      view.setZoom(newZoom);
     }
   }
 
   centerChanged() {
     const newCenter = this.model.get('center');
-    if (newCenter !== undefined && newCenter !== null) {
-      this.map.getView().setCenter(newCenter);
+    const view = this.map.getView();
+    const currentCenter = view.getCenter();
+
+    if (
+      newCenter !== undefined &&
+      newCenter !== null &&
+      (!currentCenter ||
+        currentCenter[0] !== newCenter[0] ||
+        currentCenter[1] !== newCenter[1])
+    ) {
+      view.setCenter(newCenter);
     }
   }
 


### PR DESCRIPTION
The zoom bug is because of `change:resolution` fires many times during a zoom animation, including tiny intermediate values. So `zoomChanged` code runs so we get a loop like When we click zoom-in, OL starts smooth zoom animation but intermediate zoom values get synced to Python than synced value comes back that's why `setZoom()` is called again with a partial value and animation keeps getting interrupted / flattened.

https://github.com/user-attachments/assets/73fb7e50-6f69-4888-ad5e-4d4a5f4bf811



- Closes #45 