### PR TITLE
Switch dev dependencies expressed as "extras" to pep735 dependency groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ conda activate ipyopenlayers-dev
 Install the python. This will also build the TS package.
 
 ```bash
-pip install -e ".[test, examples]"
+pip install -e . --group test --group examples
 ```
 
 When developing your extensions, you need to manually enable your extensions with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,6 @@ dev = [
     "pre-commit>=4.3.0",
     "jupyterlab>=4.0.0,<5",
 ]
-
-[project.optional-dependencies]
 docs = [
     "jupyter_sphinx",
     "nbsphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ version = "0.2.1"
 [dependency-groups]
 dev = [
     "pre-commit>=4.3.0",
+    "jupyterlab>=4.0.0,<5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
And add jupyterlab as development dependency -- needed for `jlpm`. Can also get `jlpm` with `jupyter-builder` but jupyterlab seems more practical as a dev dependency.